### PR TITLE
Resources Proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ yarn-error.log
 package-lock.json
 site/resources/
 /site/resources/
+# Local Netlify folder
+.netlify

--- a/netlify.toml
+++ b/netlify.toml
@@ -18,5 +18,5 @@
 
 [[redirects]]
   from = "/resources/*"
-  to = "https://deploy-preview-13--relaxed-tesla-8996d3.netlify.app/resources/:splat"
+  to = "https://chef-resource-hub.netlify.app/resources/:splat"
   status = 200

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,3 +15,8 @@
   from = "/brand"
   to = "http://marketing-web-communitycomponentlibrary.s3-website-us-west-2.amazonaws.com/"
   status = 301
+
+[[redirects]]
+  from = "/resources"
+  to = "https://5f6b873a44d12e000893edf1--relaxed-tesla-8996d3.netlify.app/:splat"
+  status = 200

--- a/netlify.toml
+++ b/netlify.toml
@@ -18,5 +18,5 @@
 
 [[redirects]]
   from = "/resources"
-  to = "https://5f6b873a44d12e000893edf1--relaxed-tesla-8996d3.netlify.app/:splat"
+  to = "https://deploy-preview-13--relaxed-tesla-8996d3.netlify.app/resources/:splat"
   status = 200

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,7 +13,7 @@
 
 [[redirects]]
   from = "/brand"
-  to = "http://marketing-web-communitycomponentlibrary.s3-website-us-west-2.amazonaws.com/"
+  to = "https://chef-community-components.netlify.app/"
   status = 301
 
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -17,6 +17,6 @@
   status = 301
 
 [[redirects]]
-  from = "/resources"
+  from = "/resources/*"
   to = "https://deploy-preview-13--relaxed-tesla-8996d3.netlify.app/resources/:splat"
   status = 200


### PR DESCRIPTION
**- Summary**
This PR implements a proxy rule in `netlify.toml` for /resources so that any requests to that path, will be proxied to a separate Netlify application. See chef/resources-hub#13 for related updates. 

Please note, the example presented here is reliant on a deployment preview so there are some values that will need to be updated in this PR once chef/resources-hub#13 has been merged (see below). 

The order of operations we should follow when merging this work to production goes like this... 

1. Review and merge chef/resources-hub#13 (there is one post-merge cleanup task identified on that PR)
2. Apply whatever custom domain or site name to the resources-hub Netlify project (optional but may be helpful later)
3. Update this PR so that [this value](https://github.com/chef/community-site/blob/b671d77dd6ecc3d32add0d2136d3dcf942994ee3/netlify.toml#L21) reflects the actual production URL for that project (i.e. not a deployment-preview)
4. Test & merge this PR

**- Test plan**
https://deploy-preview-44--chef-dev.netlify.app/resources

**- Description for the changelog**
Adds proxy rule to serve all request to /resources/* from another Netlify project

---

![Screen Shot 2020-09-23 at 1 45 25 PM](https://user-images.githubusercontent.com/50378/94049487-0f839680-fda3-11ea-842b-b05a966eba42.png)
