### PR TITLE
Adds Chef Habitat CLI to One Click Gets You Everything You Need section

### DIFF
--- a/site/content/tools/chef-workstation.md
+++ b/site/content/tools/chef-workstation.md
@@ -16,7 +16,7 @@ cards:
     body: >-
       Chef Workstation gives you all the tools you need to get started and includes:  
       <ul>
-        <li>Chef Workstation App</li><li>Chef Infra Client</li><li>Chef InSpec</li><li>Chef Habitat</li><li>Chef Command Line Tool</li><li>Test Kitchen</li><li>Cookstyle</li><li>Various Test Kitchen and Knife plugins</li><li>[Upgrade Lab](https://docs.chef.io/workstation/upgrade_lab/)</li>
+        <li>Chef Workstation App</li><li>Chef Infra Client</li><li>Chef InSpec</li><li>Chef Habitat CLI</li><li>Chef Command Line Tool</li><li>Test Kitchen</li><li>Cookstyle</li><li>Various Test Kitchen and Knife plugins</li><li>[Upgrade Lab](https://docs.chef.io/workstation/upgrade_lab/)</li>
       </ul>
 
   two:


### PR DESCRIPTION
Signed-off-by: Kell G <kell.gauthier@gmail.com>


**- Summary**

On page /tools/chef-workstation/, 
in section: One click gets you everything you need; 
add: "Chef Habitat CLI" 
in the listing after: Chef InSpec
and before: Chef Cоmmand Line tool

[Asana](https://app.asana.com/0/1157735291664158/1200068055862662)